### PR TITLE
fix: ignore figures and tables captions inside appendices

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -116,10 +116,20 @@
 \vspace{1cm}          % vertical space
 \listofappendicestoc  % Spis załączników
 
+% Tabele i wykresy w załączniku nie są brane pod uwagę w spisie tabel i wykresów.
+% Ich numeracja jest zresetowana.
+\captionsetup[figure]{list=no}
+\captionsetup[table]{list=no}
+
 % Załączniki
 \newpage
 \appendix{Nazwa załącznika 1}
 \lipsum[1-8]
+\begin{figure}[!h]
+	\label{fig:nowe-logo-pw2}
+	\centering \includegraphics[width=0.5\linewidth]{logopw2.png}
+	\caption{Współczesne logo Politechniki Warszawskiej - załącznik}
+\end{figure}
 
 \newpage
 \appendix{Nazwa załącznika 2}

--- a/test/referential/main-lualatex.pdf_referential.txt
+++ b/test/referential/main-lualatex.pdf_referential.txt
@@ -3388,7 +3388,12 @@ ut,iaculis
 u,mal
 suadaac,duiMaurisnibhl
 o,facilisisnon,adipiscingquis,ultric
-sa,duiZałącznikNazwazałącznikaLor
+sa,duiRysun
+kWspółcz
+sn
+logoPolit
+chnikiWarszawski
+jzałącznikZałącznikNazwazałącznikaLor
 mipsumdolorsitam
 t,cons
 ct

--- a/test/referential/main-pdflatex.pdf_referential.txt
+++ b/test/referential/main-pdflatex.pdf_referential.txt
@@ -3392,7 +3392,12 @@ ut,iaculis
 u,mal
 suadaac,duiMaurisnibhl
 o,facilisisnon,adipiscingquis,ultric
-sa,duiZałacznik˛Nazwazałacznika˛Lor
+sa,duiRysun
+kWspółcz
+sn
+logoPolit
+chnikiWarszawski
+jzałacznik˛Załacznik˛Nazwazałacznika˛Lor
 mipsumdolorsitam
 t,cons
 ct

--- a/test/referential/main-xelatex.pdf_referential.txt
+++ b/test/referential/main-xelatex.pdf_referential.txt
@@ -3388,7 +3388,12 @@ ut,iaculis
 u,mal
 suadaac,duiMaurisnibhl
 o,facilisisnon,adipiscingquis,ultric
-sa,duiZałącznikNazwazałącznikaLor
+sa,duiRysun
+kWspółcz
+sn
+logoPolit
+chnikiWarszawski
+jzałącznikZałącznikNazwazałącznikaLor
 mipsumdolorsitam
 t,cons
 ct


### PR DESCRIPTION
Fixes bug mentioned in #36 issue.

Lines added:
```
\captionsetup[figure]{list=no}
\captionsetup[table]{list=no}
```

Tested on TeXstudio (MikTeX and TeX Live 2019)

UPDATE: Works for Overleaf as well (TeX Live 2019 only). Details [here](https://www.overleaf.com/blog/tex-live-2019-upgrade-january-2020).

Source: [https://latex.org/forum/viewtopic.php?t=1316](https://latex.org/forum/viewtopic.php?t=1316)