### PR TITLE
Always use @engtitle on page with english abstract

### DIFF
--- a/src/wut-thesis.cls
+++ b/src/wut-thesis.cls
@@ -347,12 +347,7 @@
 %----------------------------
 \renewcommand{\abstract}{
     \thispagestyle{plain}
-    \ifnum \pdf@strcmp{\@lang}{pl} = 0
-        \begin{center}\textbf{\large\@engtitle}\end{center}
-    \fi
-    \ifnum \pdf@strcmp{\@lang}{en} = 0
-        \begin{center}\textbf{\large\@title}\end{center}
-    \fi
+    \begin{center}\textbf{\large\@engtitle}\end{center}
     \textbf{\\ Abstract.\xspace}
 }
 \newcommand{\keywords}{\vspace{0.5cm}\par\noindent \textbf{Keywords: \xspace}}


### PR DESCRIPTION
W jakim celu zrobione są te warunki przy tytułach w angielskiej wersji streszczenia? (i czy w ogóle są potrzebne?)
Kiedy wybiorę `\langeng` to wtedy pojawia się tytuł po polsku na stronie ze streszczeniem po angielsku.

![image](https://user-images.githubusercontent.com/4078086/152837897-5e5559da-9060-4147-b693-40e5b7bdc058.png)
