### PR TITLE
fix: Document class unknown to caption package

### DIFF
--- a/src/wut-thesis.cls
+++ b/src/wut-thesis.cls
@@ -31,6 +31,19 @@
     \hyphenpenalty=10000
     \hbadness=10000
 \fi
+% Required by caption package
+\setlength\abovecaptionskip{10\p@}
+\setlength\belowcaptionskip{0\p@}
+\long\def\@makecaption#1#2{%
+  \vskip\abovecaptionskip
+  \sbox\@tempboxa{#1: #2}%
+  \ifdim \wd\@tempboxa >\hsize
+    #1: #2\par
+  \else
+    \global \@minipagefalse
+    \hb@xt@\hsize{\hfil\box\@tempboxa\hfil}%
+  \fi
+  \vskip\belowcaptionskip}
 
 %---------------------
 % Basic dependencies


### PR DESCRIPTION
When compiling current version of the template there are two warnings, one of which is:
```
Package caption Warning: Unknown document class (or package), standard defaults will be used. See the caption package documentation for explanation.
```
To fix that, included the definitions from `article.cls` in texlive/focal 2019.20200218-1

---

The other warning related to `microtype` is supposedly [already fixed in latest version](https://github.com/schlcht/microtype/issues/19)